### PR TITLE
feat(openai): setup client helper and default gpt-4.1 (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,9 @@ SLACK_APP_TOKEN=xapp-your-app-token
 # Maximum concurrent sessions (optional) default: unlimited
 # MAX_CONCURRENT_SESSIONS=60
 
+# OpenAI credentials
+OPENAI_API_KEY=your-openai-api-key
+# OPENAI_ORG=your-openai-organization-id (optional)
+
 # OpenAI default model
 OPENAI_MODEL=gpt-4.1

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ SLACK_APP_TOKEN=xapp-your-app-token
 
 # Additional configuration (optional)
 # SLACK_LOG_LEVEL=DEBUG
+
+# Maximum concurrent sessions (optional) default: unlimited
+# MAX_CONCURRENT_SESSIONS=60
+
+# OpenAI default model
+OPENAI_MODEL=gpt-4.1

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ A Slack bot designed to collect and analyze team sentiment through interactive f
      ```
    - Update `.env` with your Slack tokens
 
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | Required for OpenAI integration |
+| `OPENAI_MODEL` | Optional. Defaults to `gpt-4.1` used by the helper |
+
 ## Running Locally
 
 Start the bot using Docker Compose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 slack-bolt==1.17.0
 python-dotenv==1.0.0
+openai>=0.27.4

--- a/src/openai_client.py
+++ b/src/openai_client.py
@@ -1,0 +1,91 @@
+"""Lightweight OpenAI client helper.
+
+Centralises API-key handling so the rest of the codebase can simply do:
+
+    from src.openai_client import chat_completion
+
+and know that the ``openai`` package is configured with credentials.
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import Any, Dict, List
+
+
+class OpenAIClientError(RuntimeError):
+    """Raised when client configuration is invalid (e.g., missing API key)."""
+
+
+_DEFAULT_MODEL = "gpt-4.1"
+
+
+def _load_openai() -> types.ModuleType:
+    """Import ``openai`` lazily.
+
+    Loading is deferred so that unit tests can inject a stub into
+    ``sys.modules`` before this function runs.
+    """
+
+    import importlib
+
+    return importlib.import_module("openai")
+
+
+def _ensure_api_key_present() -> str:
+    """Return the ``OPENAI_API_KEY`` env var or raise.
+
+    Raises
+    ------
+    OpenAIClientError
+        If the env var is missing or empty.
+    """
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise OpenAIClientError("OPENAI_API_KEY environment variable is not set.")
+    return api_key
+
+
+def get_openai_client() -> types.ModuleType:  # pragma: no cover – trivial
+    """Configure and return the ``openai`` module.
+
+    This sets ``openai.api_key`` and, if provided, ``openai.organization``.
+    Subsequent calls reuse the configured module.
+    """
+
+    openai = _load_openai()
+
+    if getattr(openai, "api_key", None):  # already configured
+        return openai
+
+    openai.api_key = _ensure_api_key_present()
+
+    org = os.getenv("OPENAI_ORG")
+    if org:
+        openai.organization = org
+
+    return openai
+
+
+def chat_completion(
+    messages: List[Dict[str, str]],
+    *,
+    model: str = _DEFAULT_MODEL,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Wrapper around ``openai.ChatCompletion.create`` with sane defaults.
+
+    Parameters
+    ----------
+    messages
+        Chat messages in OpenAI format.
+    model
+        Model id to use (default: ``gpt-4.1``).
+    kwargs
+        Additional parameters forwarded to ``ChatCompletion.create``.
+    """
+
+    openai = get_openai_client()
+
+    return openai.ChatCompletion.create(model=model, messages=messages, **kwargs)

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,80 @@
+"""Tests for the OpenAI client helper."""
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+# Module under test – will be imported lazily inside tests after env setup
+
+
+class DummyChatCompletion:  # pragma: no cover – simple stub
+    """Minimal stub mimicking openai.ChatCompletion class."""
+
+    @staticmethod
+    def create(**kwargs):  # noqa: D401,WPS110 – simple stub
+        """Return the payload we received for assertion purposes."""
+        return {"called_with": kwargs}
+
+
+def _install_openai_stub(monkeypatch):
+    """Insert a fake ``openai`` module into ``sys.modules``."""
+
+    fake_openai = ModuleType("openai")
+    fake_openai.ChatCompletion = DummyChatCompletion  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    return fake_openai
+
+
+def reload_client_module():
+    """Ensure a fresh import state for openai_client module."""
+
+    if "src.openai_client" in sys.modules:
+        del sys.modules["src.openai_client"]
+    return importlib.import_module("src.openai_client")
+
+
+def test_missing_api_key_raises(monkeypatch):
+    """get_openai_client should raise if OPENAI_API_KEY is not set."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _install_openai_stub(monkeypatch)
+
+    oc = reload_client_module()
+
+    with pytest.raises(oc.OpenAIClientError):
+        oc.get_openai_client()
+
+
+def test_successful_client(monkeypatch):
+    """get_openai_client returns configured stub when key present."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    fake_openai = _install_openai_stub(monkeypatch)
+
+    oc = reload_client_module()
+    client = oc.get_openai_client()
+
+    # Should be our stub module, and api_key attr set.
+    assert client is fake_openai
+    assert client.api_key == "test-key"
+
+
+def test_chat_completion_wrapper(monkeypatch):
+    """chat_completion should call underlying ChatCompletion.create."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    _install_openai_stub(monkeypatch)
+
+    oc = reload_client_module()
+
+    result = oc.chat_completion(
+        [{"role": "user", "content": "Hello"}],
+        temperature=0,
+    )
+
+    assert result["called_with"]["model"] == "gpt-4.1"
+    assert result["called_with"]["messages"][0]["content"] == "Hello"
+    assert result["called_with"]["temperature"] == 0


### PR DESCRIPTION
This PR implements subtask **6.1 – Setup OpenAI Client**.

### Key Points
* Added `src/openai_client.py` – lazy loads `openai`, sets API key/org, provides `chat_completion()` wrapper. Default model set to **gpt-4.1**.
* Tests (`tests/test_openai_client.py`) covering missing key, successful client config, and wrapper call.
* Added `openai` to `requirements.txt`.
* Updated `.env.example` and README with `OPENAI_MODEL` env var (default gpt-4.1).
* All tests (`pytest`) pass; `task pre-commit-run` hooks clean.

Closes #13